### PR TITLE
Enable adjoint method

### DIFF
--- a/tests/check_grad.py
+++ b/tests/check_grad.py
@@ -103,7 +103,8 @@ def get_analytical_jacobian(input, output):
         reentrant = True
         correct_grad_sizes = True
 
-    for i in range(_numel(flat_grad_output)):
+    N = tf.cast(_numel(flat_grad_output), dtype=tf.int32)
+    for i in range(N):
         flat_grad_output *= 0.
         add_one = [0] * (flat_grad_output.shape[0])
         add_one[0] = 1

--- a/tests/gradient_tests.py
+++ b/tests/gradient_tests.py
@@ -16,7 +16,6 @@ TEST_DEVICE = "gpu:0" if tf.test.is_gpu_available() else "cpu:0"
 def max_abs(tensor):
     return tf.reduce_max(tf.abs(tensor))
 
-
 class TestGradient(unittest.TestCase):
 
     def test_huen(self):
@@ -49,116 +48,132 @@ class TestGradient(unittest.TestCase):
         func = lambda y0, t_points: tfdiffeq.odeint(f, y0, t_points, method='adams')
         self.assertTrue(gradcheck(func, (y0, t_points)))
 
-    # def test_adjoint(self):
-    #     """
-    #     Test against dopri5
-    #     """
-    #     f, y0, t_points, _ = problems.construct_problem(TEST_DEVICE)
-    #
-    #     func = lambda y0, t_points: tfdiffeq.odeint(f, y0, t_points, method='dopri5')
-    #
-    #     tf.set_random_seed(0)
-    #     with tf.GradientTape() as tape:
-    #         tape.watch(t_points)
-    #         ys = func(y0, t_points)
-    #
-    #     # gradys = tf.random_uniform(ys.shape)
-    #     # ys.backward(gradys)
-    #
-    #     # reg_y0_grad = y0.grad
-    #     reg_t_grad, reg_a_grad, reg_b_grad = tape.gradient(ys, [t_points, f.a, f.b])
-    #     # reg_t_grad = t_points.grad
-    #     # reg_a_grad = f.a.grad
-    #     # reg_b_grad = f.b.grad
-    #
-    #     f, y0, t_points, _ = problems.construct_problem(TEST_DEVICE)
-    #
-    #     y0 = (y0,)
-    #
-    #     func = lambda y0, t_points: tfdiffeq.odeint_adjoint(f, y0, t_points, method='dopri5')
-    #
-    #     with tf.GradientTape() as tape:
-    #         tape.watch(t_points)
-    #         ys = func(y0, t_points)
-    #
-    #     grads = tape.gradient(ys, [t_points, f.a, f.b])
-    #     adj_t_grad, adj_a_grad, adj_b_grad = grads
-    #
-    #     # self.assertLess(max_abs(reg_y0_grad - adj_y0_grad), eps)
-    #     self.assertLess(max_abs(reg_t_grad - adj_t_grad), eps)
-    #     self.assertLess(max_abs(reg_a_grad - adj_a_grad), eps)
-    #     self.assertLess(max_abs(reg_b_grad - adj_b_grad), eps)
+    def test_adjoint(self):
+        """
+        Test against dopri5
+        """
+        tf.random.set_seed(0)
+        f, y0, t_points, _ = problems.construct_problem(TEST_DEVICE)
+    
+        func = lambda y0, t_points: tfdiffeq.odeint(f, y0, t_points, method='dopri5')
+    
+        with tf.GradientTape() as tape:
+            tape.watch(t_points)
+            ys = func(y0, t_points)
+    
+        reg_t_grad, reg_a_grad, reg_b_grad = tape.gradient(ys, [t_points, f.a, f.b])
+    
+        f, y0, t_points, _ = problems.construct_problem(TEST_DEVICE)
+    
+        y0 = (y0,)
+    
+        func = lambda y0, t_points: tfdiffeq.odeint_adjoint(f, y0, t_points, method='dopri5')
+    
+        with tf.GradientTape() as tape:
+            tape.watch(t_points)
+            ys = func(y0, t_points)
+    
+        grads = tape.gradient(ys, [t_points, f.a, f.b])
+        adj_t_grad, adj_a_grad, adj_b_grad = grads
+    
+        self.assertLess(max_abs(tf.cast(reg_t_grad, dtype=tf.float32) - tf.cast(adj_t_grad, dtype=tf.float32)), 1e-7)
+        self.assertLess(max_abs(tf.cast(reg_a_grad, dtype=tf.float32) - tf.cast(adj_a_grad, dtype=tf.float32)), 1e-7)
+        self.assertLess(max_abs(tf.cast(reg_b_grad, dtype=tf.float32) - tf.cast(adj_b_grad, dtype=tf.float32)), 1e-7)
 
 
-# class TestCompareAdjointGradient(unittest.TestCase):
-#
-#     def problem(self):
-#
-#         class Odefunc(tf.keras.Model):
-#
-#             def __init__(self):
-#                 super(Odefunc, self).__init__()
-#                 self.A = tf.Variable([[-0.1, 2.0], [-2.0, -0.1]], dtype=tf.float64)
-#                 self.unused_module = tf.keras.layers.Dense(5)
-#
-#             def call(self, t, y):
-#                 y = tfdiffeq.cast_double(y)
-#                 return tf.matmul(y ** 3, self.A)
-#
-#         y0 = tf.convert_to_tensor([[2., 0.]])
-#         t_points = tf.linspace(0., 25., 10)
-#         func = Odefunc()
-#         return func, y0, t_points
-#
-#     def test_dopri5_adjoint_against_dopri5(self):
-#         with tf.GradientTape() as tape:
-#             func, y0, t_points = self.problem()
-#             # tape.watch(t_points)
-#             tape.watch(y0)
-#             ys = tfdiffeq.odeint_adjoint(func, y0, t_points, method='dopri5')
-#
-#         adj_y0_grad = tape.gradient(ys, y0)  # y0.grad
-#         # adj_t_grad = tape.gradient(ys, t_points)  # t_points.grad
-#         adj_A_grad = tape.gradient(ys, func.A)  # func.A.grad
-#
-#         print("reached here")
-#         # w_grad, b_grad = tape.gradient(ys, func.unused_module.variables)
-#         # self.assertEqual(max_abs(w_grad), 0)
-#         # self.assertEqual(max_abs(b_grad), 0)
-#
-#         with tf.GradientTape() as tape:
-#             func, y0, t_points = self.problem()
-#             tape.watch(y0)
-#             # tape.watch(t_points)
-#             ys = tfdiffeq.odeint(func, y0, t_points, method='dopri5')
-#
-#         y_grad = tape.gradient(ys, y0)
-#         # t_grad = tape.gradient(ys, t_points)
-#         a_grad = tape.gradient(ys, func.A)
-#
-#         self.assertLess(max_abs(y_grad - adj_y0_grad), 3e-4)
-#         # self.assertLess(max_abs(t_grad - adj_t_grad), 1e-4)
-#         self.assertLess(max_abs(a_grad - adj_A_grad), 2e-3)
+class TestCompareAdjointGradient(unittest.TestCase):
 
-    # def test_adams_adjoint_against_dopri5(self):
-    #     func, y0, t_points = self.problem()
-    #     ys_ = torchdiffeq.odeint_adjoint(func, y0, t_points, method='adams')
-    #     gradys = torch.rand_like(ys_) * 0.1
-    #     ys_.backward(gradys)
-    #
-    #     adj_y0_grad = y0.grad
-    #     adj_t_grad = t_points.grad
-    #     adj_A_grad = func.A.grad
-    #     self.assertEqual(max_abs(func.unused_module.weight.grad), 0)
-    #     self.assertEqual(max_abs(func.unused_module.bias.grad), 0)
-    #
-    #     func, y0, t_points = self.problem()
-    #     ys = torchdiffeq.odeint(func, y0, t_points, method='dopri5')
-    #     ys.backward(gradys)
-    #
-    #     self.assertLess(max_abs(y0.grad - adj_y0_grad), 5e-2)
-    #     self.assertLess(max_abs(t_points.grad - adj_t_grad), 5e-4)
-    #     self.assertLess(max_abs(func.A.grad - adj_A_grad), 2e-2)
+    def problem(self):
+        tf.keras.backend.set_floatx('float64')
+
+        class Odefunc(tf.keras.Model):
+
+            def __init__(self):
+                super(Odefunc, self).__init__()
+                self.A = tf.Variable([[-0.1, -2.0], [2.0, -0.1]], dtype=tf.float64)
+                self.unused_module = tf.keras.layers.Dense(5, dtype=tf.float64)
+                self.unused_module.build((5,))
+
+            def call(self, t, y):
+                y = tfdiffeq.cast_double(y)
+                return tf.linalg.matvec(self.A, y ** 3)
+
+        y0 = tf.convert_to_tensor([2., 0.], dtype=tf.float64)
+        t_points = tf.linspace(
+            tf.constant(0., dtype=tf.float64),
+            tf.constant(25., dtype=tf.float64),
+            10
+        )
+        func = Odefunc()
+        return func, y0, t_points
+
+    def test_dopri5_adjoint_against_dopri5(self):
+        tf.keras.backend.set_floatx('float64')
+        tf.random.set_seed(0)
+        with tf.GradientTape(persistent=True) as tape:
+            func, y0, t_points = self.problem()
+            tape.watch(t_points)
+            tape.watch(y0)
+            ys = tfdiffeq.odeint_adjoint(func, y0, t_points, method='dopri5')
+
+        gradys = 0.1 * tf.random.uniform(shape=ys.shape, dtype=tf.float64)
+        adj_y0_grad, adj_t_grad, adj_A_grad = tape.gradient(
+            ys,
+            [y0, t_points, func.A],
+            output_gradients=gradys
+        )
+
+        w_grad, b_grad = tape.gradient(ys, func.unused_module.variables)
+        self.assertIsNone(w_grad)
+        self.assertIsNone(b_grad)
+
+        with tf.GradientTape() as tape:
+            func, y0, t_points = self.problem()
+            tape.watch(y0)
+            tape.watch(t_points)
+            ys = tfdiffeq.odeint(func, y0, t_points, method='dopri5')
+
+        y_grad, t_grad, a_grad = tape.gradient(
+            ys,
+            [y0, t_points, func.A],
+            output_gradients=gradys
+        )
+
+        self.assertLess(max_abs(y_grad - adj_y0_grad), 3e-4)
+        self.assertLess(max_abs(t_grad - adj_t_grad), 1e-4)
+        self.assertLess(max_abs(a_grad - adj_A_grad), 2e-3)
+
+    #def test_adams_adjoint_against_dopri5(self):
+    #    tf.keras.backend.set_floatx('float64')
+    #    tf.random.set_seed(0)
+    #    with tf.GradientTape(persistent=True) as tape:
+    #        func, y0, t_points = self.problem()
+    #        tape.watch(t_points)
+    #        tape.watch(y0)
+    #        ys = tfdiffeq.odeint_adjoint(func, y0, t_points, method='adams')
+  
+    #    gradys = 0.1 * tf.random.uniform(shape=ys.shape, dtype=tf.float64)
+    #    adj_y0_grad, adj_t_grad, adj_A_grad = tape.gradient(
+    #          ys,
+    #          [y0, t_points, func.A],
+    #          output_gradients=gradys
+    #    )
+  
+    #    with tf.GradientTape() as tape:
+    #        func, y0, t_points = self.problem()
+    #        tape.watch(y0)
+    #        tape.watch(t_points)
+    #        ys = tfdiffeq.odeint(func, y0, t_points, method='dopri5')
+  
+    #    y_grad, t_grad, a_grad = tape.gradient(
+    #        ys,
+    #        [y0, t_points, func.A],
+    #        output_gradients=gradys
+    #    )
+  
+    #    self.assertLess(max_abs(y_grad - adj_y0_grad), 3e-4)
+    #    self.assertLess(max_abs(t_grad - adj_t_grad), 1e-4)
+    #    self.assertLess(max_abs(a_grad - adj_A_grad), 2e-3)
 
 
 if __name__ == '__main__':

--- a/tests/gradient_tests.py
+++ b/tests/gradient_tests.py
@@ -52,8 +52,10 @@ class TestGradient(unittest.TestCase):
         """
         Test against dopri5
         """
-        tf.random.set_seed(0)
+        tf.compat.v1.set_random_seed(0)
         f, y0, t_points, _ = problems.construct_problem(TEST_DEVICE)
+        y0 = tf.cast(y0, tf.float64)
+        t_points = tf.cast(t_points, tf.float64)
     
         func = lambda y0, t_points: tfdiffeq.odeint(f, y0, t_points, method='dopri5')
     
@@ -64,6 +66,8 @@ class TestGradient(unittest.TestCase):
         reg_t_grad, reg_a_grad, reg_b_grad = tape.gradient(ys, [t_points, f.a, f.b])
     
         f, y0, t_points, _ = problems.construct_problem(TEST_DEVICE)
+        y0 = tf.cast(y0, tf.float64)
+        t_points = tf.cast(t_points, tf.float64)
     
         y0 = (y0,)
     
@@ -76,9 +80,9 @@ class TestGradient(unittest.TestCase):
         grads = tape.gradient(ys, [t_points, f.a, f.b])
         adj_t_grad, adj_a_grad, adj_b_grad = grads
     
-        self.assertLess(max_abs(tf.cast(reg_t_grad, dtype=tf.float32) - tf.cast(adj_t_grad, dtype=tf.float32)), 1e-7)
-        self.assertLess(max_abs(tf.cast(reg_a_grad, dtype=tf.float32) - tf.cast(adj_a_grad, dtype=tf.float32)), 1e-7)
-        self.assertLess(max_abs(tf.cast(reg_b_grad, dtype=tf.float32) - tf.cast(adj_b_grad, dtype=tf.float32)), 1e-7)
+        self.assertLess(max_abs(reg_t_grad - adj_t_grad), 1.2e-7)
+        self.assertLess(max_abs(reg_a_grad - adj_a_grad), 1.2e-7)
+        self.assertLess(max_abs(reg_b_grad - adj_b_grad), 1.2e-7)
 
 
 class TestCompareAdjointGradient(unittest.TestCase):
@@ -109,7 +113,7 @@ class TestCompareAdjointGradient(unittest.TestCase):
 
     def test_dopri5_adjoint_against_dopri5(self):
         tf.keras.backend.set_floatx('float64')
-        tf.random.set_seed(0)
+        tf.compat.v1.set_random_seed(0)
         with tf.GradientTape(persistent=True) as tape:
             func, y0, t_points = self.problem()
             tape.watch(t_points)
@@ -145,7 +149,7 @@ class TestCompareAdjointGradient(unittest.TestCase):
 
     #def test_adams_adjoint_against_dopri5(self):
     #    tf.keras.backend.set_floatx('float64')
-    #    tf.random.set_seed(0)
+    #    tf.compat.v1.set_random_seed(0)
     #    with tf.GradientTape(persistent=True) as tape:
     #        func, y0, t_points = self.problem()
     #        tape.watch(t_points)

--- a/tests/odeint_tests.py
+++ b/tests/odeint_tests.py
@@ -68,13 +68,13 @@ class TestSolverError(unittest.TestCase):
             with self.subTest(ode=ode):
                 self.assertLess(rel_error(sol, y), error_tol)
 
-    # def test_adjoint(self):
-    #     for ode in problems.PROBLEMS.keys():
-    #         f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)
-    #
-    #         y = tfdiffeq.odeint_adjoint(f, y0, t_points, method='dopri5')
-    #         with self.subTest(ode=ode):
-    #             self.assertLess(rel_error(sol, y), error_tol)
+    def test_adjoint(self):
+        for ode in problems.PROBLEMS.keys():
+            f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)
+    
+            y = tfdiffeq.odeint_adjoint(f, y0, t_points, method='dopri5')
+            with self.subTest(ode=ode):
+                self.assertLess(rel_error(sol, y), error_tol)
 
 
 class TestSolverBackwardsInTimeError(unittest.TestCase):
@@ -119,13 +119,13 @@ class TestSolverBackwardsInTimeError(unittest.TestCase):
             with self.subTest(ode=ode):
                 self.assertLess(rel_error(sol, y), error_tol)
 
-    # def test_adjoint(self):
-    #     for ode in problems.PROBLEMS.keys():
-    #         f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)
-    #
-    #         y = tfdiffeq.odeint_adjoint(f, y0, t_points, method='dopri5')
-    #         with self.subTest(ode=ode):
-    #             self.assertLess(rel_error(sol, y), error_tol)
+    def test_adjoint(self):
+        for ode in problems.PROBLEMS.keys():
+            f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)
+    
+            y = tfdiffeq.odeint_adjoint(f, y0, t_points, method='dopri5')
+            with self.subTest(ode=ode):
+                self.assertLess(rel_error(sol, y), error_tol)
 
 
 class TestNoIntegration(unittest.TestCase):

--- a/tests/odeint_tests.py
+++ b/tests/odeint_tests.py
@@ -71,6 +71,9 @@ class TestSolverError(unittest.TestCase):
     def test_adjoint(self):
         for ode in problems.PROBLEMS.keys():
             f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)
+            y0 = tf.cast(y0, tf.float64)
+            t_points = tf.cast(t_points, tf.float64)
+            sol = tf.cast(sol, tf.float64)
     
             y = tfdiffeq.odeint_adjoint(f, y0, t_points, method='dopri5')
             with self.subTest(ode=ode):
@@ -122,6 +125,9 @@ class TestSolverBackwardsInTimeError(unittest.TestCase):
     def test_adjoint(self):
         for ode in problems.PROBLEMS.keys():
             f, y0, t_points, sol = problems.construct_problem(TEST_DEVICE, reverse=True)
+            y0 = tf.cast(y0, tf.float64)
+            t_points = tf.cast(t_points, tf.float64)
+            sol = tf.cast(sol, tf.float64)
     
             y = tfdiffeq.odeint_adjoint(f, y0, t_points, method='dopri5')
             with self.subTest(ode=ode):

--- a/tfdiffeq/__init__.py
+++ b/tfdiffeq/__init__.py
@@ -1,6 +1,6 @@
 # Core imports
 from tfdiffeq.odeint import odeint
-# from tfdiffeq.adjoint import odeint_adjoint
+from tfdiffeq.adjoint import odeint_adjoint
 
 # Utility functions
 from tfdiffeq.misc import cast_double, func_cast_double

--- a/tfdiffeq/adams.py
+++ b/tfdiffeq/adams.py
@@ -31,7 +31,7 @@ def g_and_explicit_phi(prev_t, next_t, implicit_phi, k):
     dt = next_t - prev_t[0]
 
     with tf.device(prev_t[0].device):
-        g = tf.Variable(tf.zeros([k + 1]))
+        g = tf.Variable(tf.zeros([k + 1]), trainable=False)
 
     explicit_phi = collections.deque(maxlen=k)
     beta = move_to_device(tf.convert_to_tensor(1.), prev_t[0].device)

--- a/tfdiffeq/adjoint.py
+++ b/tfdiffeq/adjoint.py
@@ -34,8 +34,7 @@ def OdeintAdjointMethod(*args):
     rtol = _arguments.rtol
     atol = _arguments.atol
 
-    assert len(args) >= 3, 'Internal error: all arguments required.'
-    y0, t, flat_params = args[:-2], args[-2], args[-1]
+    y0, t = args[:-1], args[-1]
 
     # registers `t` as a Variable that needs a gred, then resets it to a Tensor
     # for the `odeint` function to work. This is done to force tf to allow us to
@@ -48,17 +47,13 @@ def OdeintAdjointMethod(*args):
     @func_cast_double
     def grad(*grad_output, variables=None):
         global _arguments
-        # t, flat_params, *ans = ctx.saved_tensors
-        # ans = tuple(ans)
-        # func, rtol, atol, method, options = ctx.func, ctx.rtol, ctx.atol, ctx.method, ctx.options
+        flat_params = _flatten(variables)
+
         func = _arguments.func
         method = _arguments.method
         options = _arguments.options
         rtol = _arguments.rtol
         atol = _arguments.atol
-
-        print("Gradient Output : ", grad_output)
-        print("Variables : ", variables)
 
         n_tensors = len(ans)
         f_params = tuple(variables)
@@ -70,26 +65,22 @@ def OdeintAdjointMethod(*args):
 
             y, adj_y = y_aug[:n_tensors], y_aug[n_tensors:2 * n_tensors]  # Ignore adj_time and adj_params.
 
-            # t = tf.get_variable('t', initializer=t)
-            # y = tuple(tf.Variable(y_) for y_ in y)
-
             with tf.GradientTape() as tape:
                 tape.watch(t)
                 tape.watch(y)
                 func_eval = func(t, y)
                 func_eval = cast_double(func_eval)
 
-            # print('y', [y_.numpy().shape for y_ in y])
-            # print('adj y', [a.numpy().shape for a in adj_y])
-
-            vjp_t, *vjp_y_and_params = tape.gradient(func_eval, (t,) + y + f_params,
-                                                     # list(-adj_y_ for adj_y_ in adj_y),
-                                                     )
+            gradys = tf.expand_dims(list(-adj_y_ for adj_y_ in adj_y), axis=0)
+            #gradys = tf.reshape(list(-adj_y_ for adj_y_ in adj_y), (1, -1))
+            vjp_t, *vjp_y_and_params = tape.gradient(
+                func_eval,
+                (t,) + y + f_params,
+                output_gradients=gradys
+             )
 
             vjp_y = vjp_y_and_params[:n_tensors]
             vjp_params = vjp_y_and_params[n_tensors:]
-            # print('vjp_y', [v.numpy().shape if v is not None else None for v in vjp_y])
-            # print()
 
             # autograd.grad returns None if no gradient, set to zero.
             vjp_t = tf.zeros_like(t, dtype=t.dtype) if vjp_t is None else vjp_t
@@ -101,12 +92,6 @@ def OdeintAdjointMethod(*args):
             if _check_len(f_params) == 0:
                 vjp_params = tf.convert_to_tensor(0., dtype=vjp_y[0].dype)
                 vjp_params = move_to_device(vjp_params, vjp_y[0].device)
-
-            # print('vjp_t grad', vjp_t.numpy())
-            # print('vjp_params', [v.numpy() for v in vjp_params])
-            # print('vjp y grads', [v.numpy().shape for v in vjp_y])
-            # print("LEN FUNC EVALS : ", len(func_eval))
-            # print()
 
             return (*func_eval, *vjp_y, vjp_t, vjp_params)
 
@@ -152,13 +137,6 @@ def OdeintAdjointMethod(*args):
 
             aug_y0 = (*ans_i, *adj_y, adj_time, adj_params)
 
-            # print('ans i', [a.numpy().shape for a in ans_i])
-            # print('adj y', [a.numpy().shape for a in adj_y])
-            # print('adj time', adj_time.numpy().shape)
-            # print('adj params', adj_params.numpy().shape)
-
-            # print()
-
             aug_ans = odeint(
                 augmented_dynamics,
                 aug_y0,
@@ -182,12 +160,6 @@ def OdeintAdjointMethod(*args):
         time_vjps.append(adj_time)
         time_vjps = tf.concat(time_vjps[::-1], 0)
 
-        print()
-        print('adj y', len(adj_y))
-        print('time vjps', time_vjps.shape)
-        print('adj params', adj_params.shape)
-        print()
-
         # reshape the parameters back into the correct variable shapes
         var_flat_lens = [_numel(v, dtype=tf.int32).numpy() for v in variables]
         var_shapes = [v.shape for v in variables]
@@ -196,27 +168,7 @@ def OdeintAdjointMethod(*args):
         adj_params_list = [tf.reshape(p, v_shape)
                            for p, v_shape in zip(adj_params_splits, var_shapes)]
 
-        # add the time gradient (always the first tensor in list of variables)
-        # adj_params.insert(0, time_vjps)
-
-        # adj_y_grad_vars = list(zip(adj_y, grad_output))
-        # time_grad_vars = list((time_vjps, t))
-        model_vars = list(adj_params_list)  # list(zip(adj_params, variables))
-
-        grad_vars = model_vars  # adj_y_grad_vars + time_grad_vars + model_vars
-        # print('adj y grad', len(adj_y_grad_vars))
-        # print('time grad', len(time_grad_vars))
-        print('model grad', len(model_vars))
-        print('model grad values', [v for v in grad_vars])
-        print()
-
-        # if len(adj_y) == 1:
-        #     adj_y = adj_y[0]
-
-        return (adj_y, model_vars)
-        # print("Grad_vars : ", grad_vars)
-        # return zip(*grad_vars)  # (*adj_y, time_vjps, adj_params, None, None)
-        # return (*adj_y, time_vjps, adj_params)
+        return (*adj_y, time_vjps), adj_params_list
 
     return ans, grad
 
@@ -247,12 +199,10 @@ def odeint_adjoint(func, y0, t, rtol=1e-6, atol=1e-12, method=None, options=None
         if not func.built:
             _ = func(t, y0)
 
-        flat_params = _flatten(func.variables)
-
         global _arguments
         _arguments = _Arguments(func, method, options, rtol, atol)
 
-        ys = OdeintAdjointMethod(*y0, t, flat_params)
+        ys = OdeintAdjointMethod(*y0, t)
 
         if tensor_input or type(ys) == tuple or type(ys) == list:
             ys = ys[0]

--- a/tfdiffeq/adjoint.py
+++ b/tfdiffeq/adjoint.py
@@ -71,8 +71,9 @@ def OdeintAdjointMethod(*args):
                 func_eval = func(t, y)
                 func_eval = cast_double(func_eval)
 
-            gradys = tf.expand_dims(list(-adj_y_ for adj_y_ in adj_y), axis=0)
-            #gradys = tf.reshape(list(-adj_y_ for adj_y_ in adj_y), (1, -1))
+            gradys = tf.stack(list(-adj_y_ for adj_y_ in adj_y))
+            if len(gradys.shape) < len(func_eval.shape):
+                gradys = tf.expand_dims(gradys, axis=0)
             vjp_t, *vjp_y_and_params = tape.gradient(
                 func_eval,
                 (t,) + y + f_params,


### PR DESCRIPTION
Fixes #2 

This PR proposes a way to make the adjoint method work with tensorflow custom_gradient interface. The main changes are in `tfdiffeq/adjoint.py` and can be summarized as:

1. Don't pass the ODE parameters to `OdeintAdjointMethod` function. We instead get these parameters from the `variables` keyword argument of `grad` function.
2. `tf.custom_gradient` requires `grad` function to return two sets of gradients as a pair. These are
  i. The gradient with respect to the inputs of `OdeintAdjointMethod`. These are `x0` and `t` in our case.
  ii. The gradient with respect to the parameters which are `tf.Variable` objects stored in our ODE object.
3. To prevent getting all the `tf.Variable` objects created in adams optimizer, we mark them as non-trainable. However, there still seems

Caveats: I wasn't able to make the method work with the adams method (therefore adams - adjoint test is not enabled either). The problem is that the elements of the tuple returned from `augmented_dynamics` function have different shapes, and this causes problems with `adams.py:138`